### PR TITLE
Feature/minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@
 .settings/
 .es/
 .es.tar.gz
-
+.idea
+*.iml

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Stash Codesearch was written by Palantir Technologies and open-sourced under the
 
 This project uses versions determined by `git describe --dirty='-dirty' --abbrev=12`, and thus versions are of the form 1.2.3-N-gX where N is the number of commits since that tag and X is the exact 12-character prefix of the sha1 the version was built from.
 
-If you build using `./build/invoke-sdk.sh`, the version will be set automatically.  Alternatively, you can set the DOMAIN_VERSION environemnt variable when invoking maven directly to override the version.
+If you build using `./bin/invoke-sdk.sh`, the version will be set automatically.  Alternatively, you can set the DOMAIN_VERSION environemnt variable when invoking maven directly to override the version.
 
 This is important because Atlassian plugins use OSGi and their version strings *must* be of the form:
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,9 @@
             <plugin>
                 <groupId>com.atlassian.maven.plugins</groupId>
                 <artifactId>bitbucket-maven-plugin</artifactId>
-                <version>6.1.0</version>
+                <version>${amps.version}</version>
                 <extensions>true</extensions>
+
                 <configuration>
                     <products>
                         <product>
@@ -162,11 +163,13 @@
             <artifactId>sal-api</artifactId>
             <scope>provided</scope>
         </dependency>
+
     </dependencies>
     <properties>
+        <dev.mode>true</dev.mode>
         <amps.version>6.1.0</amps.version>
-        <bitbucket.version>4.0.2</bitbucket.version>
-        <bitbucket.data.version>${bitbucket.version}</bitbucket.data.version>
+        <bitbucket.version>4.0.0</bitbucket.version> <!-- see https://maven.atlassian.com/content/groups/public/com/atlassian/bitbucket/server/bitbucket-webapp/ -->
+        <bitbucket.data.version>${bitbucket.version}</bitbucket.data.version> <!-- see https://maven.atlassian.com/content/groups/public/com/atlassian/bitbucket/server/bitbucket-it-resources/ -->
         <bitbucket.containerId>tomcat8x</bitbucket.containerId>
         <elasticsearch.version>1.6.0</elasticsearch.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/palantir/stash/codesearch/updater/SearchUpdaterImpl.java
+++ b/src/main/java/com/palantir/stash/codesearch/updater/SearchUpdaterImpl.java
@@ -18,6 +18,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.PatternSyntaxException;
 
+import com.atlassian.sal.api.lifecycle.LifecycleAware;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequestBuilder;
 import org.elasticsearch.cluster.metadata.AliasMetaData;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
@@ -37,7 +38,7 @@ import com.palantir.stash.codesearch.logger.PluginLoggerFactory;
 import com.palantir.stash.codesearch.repository.RepositoryServiceManager;
 import com.palantir.stash.codesearch.search.SearchFilterUtils;
 
-public class SearchUpdaterImpl implements SearchUpdater, DisposableBean {
+public class SearchUpdaterImpl implements SearchUpdater, LifecycleAware {
 
     private static class ResizableSemaphore extends Semaphore {
 
@@ -130,9 +131,18 @@ public class SearchUpdaterImpl implements SearchUpdater, DisposableBean {
         this.concurrencyLimit = GlobalSettings.MAX_CONCURRENT_INDEXING_LB;
         this.semaphore = new ResizableSemaphore(concurrencyLimit, true);
         this.jobPool = new ScheduledThreadPoolExecutor(concurrencyLimit * 5);
+    }
+
+    @Override
+    public void onStart() {
         initializeAliasedIndex(ES_UPDATEALIAS, false);
         redirectAndDeleteAliasedIndex(ES_SEARCHALIAS, ES_UPDATEALIAS);
         settingsManager.addSearchUpdater(this);
+    }
+
+    @Override
+    public void onStop() {
+        jobPool.shutdown();
     }
 
     // Return the name of the index pointed to by an alias (null if no index found)
@@ -618,6 +628,7 @@ public class SearchUpdaterImpl implements SearchUpdater, DisposableBean {
 
     @Override
     public boolean reindexAll() {
+        log.info("******** Reindexing All ********");
         GlobalSettings globalSettings = settingsManager.getGlobalSettings();
         if (!globalSettings.getIndexingEnabled()) {
             log.warn("Not performing a complete reindex since indexing is disabled");
@@ -664,6 +675,7 @@ public class SearchUpdaterImpl implements SearchUpdater, DisposableBean {
         } finally {
             isReindexingAll.getAndSet(false);
         }
+        log.info("******** Reindexing Completed ********");
         return true;
     }
 
@@ -681,11 +693,6 @@ public class SearchUpdaterImpl implements SearchUpdater, DisposableBean {
             jobPool.setMaximumPoolSize(concurrencyLimit * 5);
             semaphore.resize(concurrencyLimit);
         }
-    }
-
-    @Override
-    public void destroy() {
-        jobPool.shutdown();
     }
 
 }

--- a/src/main/java/com/palantir/stash/codesearch/updater/SearchUpdaterImpl.java
+++ b/src/main/java/com/palantir/stash/codesearch/updater/SearchUpdaterImpl.java
@@ -173,7 +173,6 @@ public class SearchUpdaterImpl implements SearchUpdater, LifecycleAware {
         String newIndex = random.nextLong() + "-" + System.nanoTime();
         try {
             es.getClient().admin().indices().prepareCreate(newIndex)
-                    // todo: this feels like it should be coming from a classpath resource since it's all static
                 // Latest indexed note schema
                 .addMapping("latestindexed",
                     jsonBuilder().startObject()
@@ -587,9 +586,23 @@ public class SearchUpdaterImpl implements SearchUpdater, LifecycleAware {
         }
         log.warn("Manual reindex triggered for {}^{} (expensive operation, use sparingly)", projectKey, repositorySlug);
 
-        //todo: decide if it's worthwhile to disable refresh for faster bulk indexing or not.
-
-        deleteRepository(projectKey, repositorySlug);
+        // Delete documents for this repository
+        log.warn("Deleting {}^{} for manual reindexing", projectKey, repositorySlug);
+        for (int i = 0; i < 5; ++i) { // since ES doesn't have a refresh setting for delete by
+                                      // query requests, we just spam multiple requests.
+            es.getClient().prepareDeleteByQuery(ES_UPDATEALIAS)
+                .setRouting(projectKey + '^' + repositorySlug)
+                .setQuery(QueryBuilders.filteredQuery(
+                    QueryBuilders.matchAllQuery(),
+                    sfu.projectRepositoryFilter(projectKey, repositorySlug)))
+                .get();
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException e) {
+                log.warn("Caught InterruptedException while trying to sleep", e);
+            }
+        }
+        log.warn("Deletion of {}^{} completed", projectKey, repositorySlug);
 
         // Search for repository
         Repository repository = repositoryServiceManager.getRepositoryService().getBySlug(
@@ -600,62 +613,21 @@ public class SearchUpdaterImpl implements SearchUpdater, LifecycleAware {
         }
 
         // Submit and wait for each job
-        List<Future<Void>> futures = updateRepository(repository);
-        waitForFutures(futures);
-
-        log.warn("Manual reindex of {}^{} completed", projectKey, repositorySlug);
-        return true;
-    }
-
-    private List<Future<Void>> updateRepository(Repository repository) {
         List<Future<Void>> futures = new ArrayList<Future<Void>>();
         for (Branch branch : repositoryServiceManager.getBranchMap(repository).values()) {
             // No need to explicitly trigger reindex, since index is empty.
             futures.add(submitAsyncUpdate(repository, branch.getId(), 0));
         }
-        return futures;
-    }
-
-    private void waitForFutures(List<Future<Void>> futures) {
         for (Future<Void> future : futures) {
             waitForFuture(future);
         }
-    }
 
-    private void deleteRepository(final String projectKey, final String repositorySlug) {
-        // Delete documents for this repository
-        log.warn("Deleting {}^{} for manual reindexing", projectKey, repositorySlug);
-        for (int i = 0; i < 5; ++i) { // since ES doesn't have a refresh setting for delete by
-            // query requests, we just spam multiple requests.
-            es.getClient().prepareDeleteByQuery(ES_UPDATEALIAS)
-                    .setRouting(projectKey + '^' + repositorySlug)
-                    .setQuery(QueryBuilders.filteredQuery(
-                            QueryBuilders.matchAllQuery(),
-                            sfu.projectRepositoryFilter(projectKey, repositorySlug)))
-                    .get();
-            try {
-                Thread.sleep(200);
-            } catch (InterruptedException e) {
-                log.warn("Caught InterruptedException while trying to sleep", e);
-            }
-        }
-        log.warn("Deletion of {}^{} completed", projectKey, repositorySlug);
-    }
-
-    private void setIndexInterval(String interval) {
-        es.getClient().admin().indices().prepareUpdateSettings(ES_UPDATEALIAS)
-                .setSettings(ImmutableSettings.builder()
-                        .put("index.refresh_interval", interval))
-                .get();
-    }
-
-    private void optimiseIndicies() {
-        es.getClient().admin().indices().prepareOptimize(ES_UPDATEALIAS).get();
-        redirectAndDeleteAliasedIndex(ES_SEARCHALIAS, ES_UPDATEALIAS);
+        log.warn("Manual reindex of {}^{} completed", projectKey, repositorySlug);
+        return true;
     }
 
     @Override
-    public boolean reindexAll() {// todo: convert this to some kind of long running task and display progress
+    public boolean reindexAll() {
         log.warn("******** Reindexing All ********");
         GlobalSettings globalSettings = settingsManager.getGlobalSettings();
         if (!globalSettings.getIndexingEnabled()) {
@@ -676,18 +648,30 @@ public class SearchUpdaterImpl implements SearchUpdater, LifecycleAware {
             });
 
             // Disable refresh for faster bulk indexing
-            setIndexInterval("-1");
+            es.getClient().admin().indices().prepareUpdateSettings(ES_UPDATEALIAS)
+                .setSettings(ImmutableSettings.builder()
+                    .put("index.refresh_interval", "-1"))
+                .get();
 
             // Submit and wait for each job
             List<Future<Void>> futures = new ArrayList<Future<Void>>();
             for (Repository repo : repositoryServiceManager.getRepositoryMap(null).values()) {
-                futures.addAll(updateRepository(repo));
+                for (Branch branch : repositoryServiceManager.getBranchMap(repo).values()) {
+                    // No need to explicitly trigger reindex, since index is empty.
+                    futures.add(submitAsyncUpdate(repo, branch.getId(), 0));
+                }
             }
-            waitForFutures(futures);
+            for (Future<Void> future : futures) {
+                waitForFuture(future);
+            }
 
             // Re-enable refresh & optimize, enable searching on index
-            setIndexInterval("1s");
-            optimiseIndicies();
+            es.getClient().admin().indices().prepareUpdateSettings(ES_UPDATEALIAS)
+                .setSettings(ImmutableSettings.builder()
+                    .put("index.refresh_interval", "1s"))
+                .get();
+            es.getClient().admin().indices().prepareOptimize(ES_UPDATEALIAS).get();
+            redirectAndDeleteAliasedIndex(ES_SEARCHALIAS, ES_UPDATEALIAS);
         } finally {
             isReindexingAll.getAndSet(false);
         }

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -33,6 +33,7 @@
 
     <component key="es" class="com.palantir.stash.codesearch.elasticsearch.ElasticSearchImpl" public="true">
         <interface>com.palantir.stash.codesearch.elasticsearch.ElasticSearch</interface>
+        <interface>com.atlassian.sal.api.lifecycle.LifecycleAware</interface>
     </component>
 
     <component key="settings-manager" class="com.palantir.stash.codesearch.admin.SettingsManagerImpl" public="true">
@@ -49,6 +50,7 @@
 
     <component key="search-updater" class="com.palantir.stash.codesearch.updater.SearchUpdaterImpl" public="true">
         <interface>com.palantir.stash.codesearch.updater.SearchUpdater</interface>
+        <interface>com.atlassian.sal.api.lifecycle.LifecycleAware</interface>
     </component>
 
     <component key="indexer-event-listener" class="com.palantir.stash.codesearch.event.IndexerEventListener" />


### PR DESCRIPTION
This moves the initialisation of the ES connections out of the constructors, both to improve application startup speed and avoid the plugin being disabled if the ES server is not available.

I've dropped the version of BBS that it's being built against so that I can use atlas-debug.

Next steps will be to move the configuration of the ES server into the admin dialog, and add a progress indicator to the full reindex - we have a massive repository and we want to be able to host the ES on a different box to stash and I hate hard-coding things :D
